### PR TITLE
Correct envelope sender & recipient format

### DIFF
--- a/lib/Net/SMTP/TLS/ButMaintained.pm
+++ b/lib/Net/SMTP/TLS/ButMaintained.pm
@@ -268,7 +268,7 @@ sub _addr {
 sub mail {
 	my $me	= shift;
 	my $from= shift;
-	$me->_command("MAIL FROM: "._addr($from));
+	$me->_command("MAIL FROM:"._addr($from));
 	my ($num,$txt) = $me->_response();
 	if(not $num == 250){
 		croak "Could't set FROM: $num $txt\n";
@@ -282,7 +282,7 @@ sub recipient {
 	my $addr;
 	foreach $addr (@_)
 	{
-		$me->_command("RCPT TO: "._addr($addr));
+		$me->_command("RCPT TO:"._addr($addr));
 		my ($num,$txt) = $me->_response();
 		if(not $num == 250){
 			croak "Couldn't send TO <$addr>: $num $txt\n";


### PR DESCRIPTION
See RFC 821 and RFC 2821

The proper format is this:

  MAIL FROM:sender@example.com
  RCPT TO:sender@example.com

Note that there is NO space after the colon (:) as exists in Mail headers.
