### PR TITLE
Net::SMTP::TLS::ButMaintained: fix spelling

### DIFF
--- a/lib/Net/SMTP/TLS/ButMaintained.pm
+++ b/lib/Net/SMTP/TLS/ButMaintained.pm
@@ -46,7 +46,7 @@ Hello - hostname used in the EHLO command
 
 Port - port to connect to the SMTP service (defaults to 25)
 
-Timeout - Timeout for inital socket connection (defaults to 5, passed directly to L<IO::Socket::INET>)
+Timeout - Timeout for initial socket connection (defaults to 5, passed directly to L<IO::Socket::INET>)
 
 User - username for SMTP AUTH
 


### PR DESCRIPTION
This PR is a submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/october.html)  (link not ready yet, hopefully soon when Neil updates the site.)

`s/inital/initial/`, fixes https://rt.cpan.org/Public/Bug/Display.html?id=126969